### PR TITLE
Support propshaft

### DIFF
--- a/lib/tasks/hanmoto_tasks.rake
+++ b/lib/tasks/hanmoto_tasks.rake
@@ -2,7 +2,9 @@ namespace :hanmoto do
   desc 'generate public pages'
   task publish: :environment do
     # NOTE: clear cache
-    ActionView::Base.assets_manifest = Sprockets::Railtie.build_manifest(Rails.application)
+    if defined?(ActionView::Base.assets_manifest)
+      ActionView::Base.assets_manifest = Sprockets::Railtie.build_manifest(Rails.application)
+    end
     Hanmoto::Task.run(**Hanmoto.configuration.to_h)
   end
 end


### PR DESCRIPTION
- Execute `rake hanmoto:publish` without `require sprockets` causes `NameError: uninitialized constant Sprockets`
- `ActionView::Base.assets_manifest` is defined by sprockets